### PR TITLE
feat: Add private blob storage download endpoint for reports

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopacruscottobackend
 description: Microservice description
 type: application
-version: 0.262.0
-appVersion: 0.11.10
+version: 0.263.0
+appVersion: 0.11.10-1-feature/add-report-download-endpoint
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-cruscotto-backend
-    tag: "0.11.10"
+    tag: "0.11.10-1-feature/add-report-download-endpoint"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-cruscotto-backend
-    tag: "0.11.10"
+    tag: "0.11.10-1-feature/add-report-download-endpoint"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/uat/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-cruscotto-backend
-    tag: "0.11.10"
+    tag: "0.11.10-1-feature/add-report-download-endpoint"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/uat/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -9587,6 +9587,109 @@
           }
         }
       }
+    },
+    "/api/reports/{id}/download": {
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "summary": "Download a completed report file",
+        "description": "Downloads a completed report file directly from private Azure Blob Storage. The backend acts as a proxy, authenticating with Azure and streaming the file to the client. This approach works with private blob storage where clients cannot access blobs directly.",
+        "operationId": "downloadReport",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Report ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "example": 123
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File downloaded successfully",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "headers": {
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Attachment with filename",
+                "example": "attachment; filename=\"Report_INST_06457411004_20260610_180651396.zip\""
+              },
+              "Content-Length": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "File size in bytes",
+                "example": "15728640"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Report is not completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "timestamp": "2026-07-08T15:30:00Z",
+                  "status": 400,
+                  "error": "Bad Request",
+                  "message": "Report is not completed, current status: IN_PROGRESS",
+                  "path": "/api/reports/123/download"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Report not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "timestamp": "2026-07-08T15:30:00Z",
+                  "status": 404,
+                  "error": "Not Found",
+                  "message": "Report not found: 123",
+                  "path": "/api/reports/123/download"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Failed to download from blob storage",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "timestamp": "2026-07-08T15:30:00Z",
+                  "status": 500,
+                  "error": "Internal Server Error",
+                  "message": "Failed to download report file: File not found in Azure Blob Storage",
+                  "path": "/api/reports/123/download"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "unlicensed"
     },
-    "version": "0.11.10"
+    "version": "0.11.10-1-feature/add-report-download-endpoint"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.nexigroup.pagopa.cruscotto</groupId>
   <artifactId>pagopa-cruscotto-backend</artifactId>
-  <version>0.11.10</version>
+  <version>0.11.10-1-feature/add-report-download-endpoint</version>
   <packaging>jar</packaging>
   <name>PagoPa Cruscotto Backend</name>
   <description>PagoPa Cruscotto Backend</description>

--- a/src/main/java/com/nexigroup/pagopa/cruscotto/service/ReportGenerationService.java
+++ b/src/main/java/com/nexigroup/pagopa/cruscotto/service/ReportGenerationService.java
@@ -5,6 +5,8 @@ import com.nexigroup.pagopa.cruscotto.service.dto.ReportGenerationRequestDTO;
 import com.nexigroup.pagopa.cruscotto.service.dto.ReportGenerationResponseDTO;
 import com.nexigroup.pagopa.cruscotto.service.exception.DuplicateReportException;
 import com.nexigroup.pagopa.cruscotto.service.exception.ReportGenerationException;
+import com.nexigroup.pagopa.cruscotto.service.exception.ReportNotFoundException;
+
 import java.util.List;
 
 /**

--- a/src/main/java/com/nexigroup/pagopa/cruscotto/service/ReportGenerationService.java
+++ b/src/main/java/com/nexigroup/pagopa/cruscotto/service/ReportGenerationService.java
@@ -65,6 +65,17 @@ public interface ReportGenerationService {
     ReportGenerationResponseDTO getReportStatus(Long reportId);
 
     /**
+     * Download a report file directly from blob storage.
+     * Used when blob storage is private and cannot be accessed directly by the client.
+     *
+     * @param reportId the report ID
+     * @return the file content as byte array
+     * @throws ReportNotFoundException if report not found
+     * @throws ReportGenerationException if report is not completed or download fails
+     */
+    byte[] downloadReportFile(Long reportId) throws ReportNotFoundException, ReportGenerationException;
+
+    /**
      * Get the download URL for a report.
      *
      * @param reportId the report ID

--- a/src/main/java/com/nexigroup/pagopa/cruscotto/service/impl/ReportGenerationServiceImpl.java
+++ b/src/main/java/com/nexigroup/pagopa/cruscotto/service/impl/ReportGenerationServiceImpl.java
@@ -553,4 +553,37 @@ public class ReportGenerationServiceImpl implements ReportGenerationService {
 
         return dto;
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public byte[] downloadReportFile(Long reportId) throws ReportNotFoundException, ReportGenerationException {
+        log.debug("Downloading report file for report: {}", reportId);
+        
+        ReportGeneration report = reportGenerationRepository.findById(reportId)
+            .orElseThrow(() -> new ReportNotFoundException("Report not found: " + reportId));
+        
+        if (report.getStatus() != ReportStatus.COMPLETED) {
+            throw new ReportGenerationException("Report is not completed, current status: " + report.getStatus());
+        }
+        
+        ReportFile reportFile = report.getReportFile();
+        if (reportFile == null) {
+            throw new ReportGenerationException("Report file not found for report: " + reportId);
+        }
+        
+        try {
+            // Extract blob path and filename from blobName
+            String blobName = reportFile.getBlobName();
+            int lastSlashIndex = blobName.lastIndexOf('/');
+            String blobPath = lastSlashIndex > 0 ? blobName.substring(0, lastSlashIndex) : "";
+            String blobFileName = lastSlashIndex > 0 ? blobName.substring(lastSlashIndex + 1) : blobName;
+            
+            byte[] fileContent = blobStorageService.download(blobPath, blobFileName);
+            log.info("Report file downloaded successfully for report id: {}, size: {} bytes", reportId, fileContent.length);
+            return fileContent;
+        } catch (Exception e) {
+            log.error("Failed to download report file for report: {}", reportId, e);
+            throw new ReportGenerationException("Failed to download report file: " + e.getMessage(), e);
+        }
+    }
 }

--- a/src/main/java/com/nexigroup/pagopa/cruscotto/web/rest/ReportGenerationController.java
+++ b/src/main/java/com/nexigroup/pagopa/cruscotto/web/rest/ReportGenerationController.java
@@ -78,4 +78,30 @@ public class ReportGenerationController {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), e);
         }
     }
+
+    @GetMapping("/{id}/download")
+    public ResponseEntity<byte[]> downloadReport(@PathVariable Long id) {
+        try {
+            ReportGenerationResponseDTO report = reportService.getReportStatus(id);
+            
+            if (report == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Report not found");
+            }
+            
+            if (!"COMPLETED".equals(report.getStatus())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                    "Report is not completed, current status: " + report.getStatus());
+            }
+            
+            byte[] fileContent = reportService.downloadReportFile(id);
+            
+            return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=\"" + report.getFileName() + "\"")
+                .header("Content-Type", "application/octet-stream")
+                .header("Content-Length", String.valueOf(fileContent.length))
+                .body(fileContent);
+        } catch (ReportGenerationException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), e);
+        }
+    }
 }


### PR DESCRIPTION
# feat: Add private blob storage download endpoint for reports

## Problem Statement
When Azure Blob Storage is configured with private access (no public endpoints), clients cannot download files using SAS URLs directly because they lack Azure authentication credentials. This results in `AuthorizationFailure` errors when attempting to access blob storage from the frontend:

```
<Code>AuthorizationFailure</Code>
<Message>This request is not authorized to perform this operation. RequestId:2cb1083c-501e-0011-53e7-0339e2000000</Message>
```

The current implementation generates SAS URLs that require direct blob storage access, which doesn't work in private environments.

## Solution
Implement a backend proxy endpoint that:
1. **Authenticates** with Azure Blob Storage using the backend's connection string
2. **Downloads** the file from the private blob storage
3. **Streams** the file to the client via HTTP response

This approach is secure and works seamlessly with private storage accounts since the backend has the necessary credentials.

## Changes

### 1. Service Interface - `ReportGenerationService.java`
- Added `downloadReportFile(Long reportId)` method to download report files directly

### 2. Service Implementation - `ReportGenerationServiceImpl.java`
- Implements `downloadReportFile()` with:
  - Report existence and completion status validation
  - Blob path/filename extraction from stored blob name
  - Direct download from private Azure Blob Storage
  - Comprehensive error handling and logging

### 3. Controller - `ReportGenerationController.java`
- New endpoint: `GET /api/reports/{id}/download`
- Returns binary file with proper headers:
  - `Content-Disposition`: attachment with filename
  - `Content-Type`: application/octet-stream
  - `Content-Length`: file size
- Error responses:
  - **400 Bad Request**: Report not in COMPLETED status
  - **404 Not Found**: Report doesn't exist
  - **500 Internal Server Error**: Download from blob storage failed

### 4. OpenAPI Documentation - `openapi.json`
- Full API documentation for the new endpoint with examples
- Request/response schemas
- Error response examples

## Architecture

```
Frontend
    ↓
GET /api/reports/{id}/download
    ↓
Backend (ReportGenerationController)
    ↓
Validates report status
    ↓
ReportGenerationService.downloadReportFile()
    ↓
AzureBlobStorageService.download()
    ↓
Azure Blob Storage (Private)
    ↓
Binary file stream back to Frontend
```

## Frontend Usage Example

```javascript
// Download report
const response = await fetch(`/api/reports/{reportId}/download`);
const blob = await response.blob();

// Trigger browser download
const url = window.URL.createObjectURL(blob);
const link = document.createElement('a');
link.href = url;
link.download = response.headers.get('Content-Disposition')
  .split('filename="')[1]?.split('"')[0] || 'report.zip';
link.click();
window.URL.revokeObjectURL(url);
```

## Benefits
✅ Works with **private blob storage** (no public access required)  
✅ **Secure** - backend handles authentication, credentials not exposed to client  
✅ **Simple** - single endpoint for downloading completed reports  
✅ **Reliable** - proper error handling and status validation  
✅ **Well documented** - OpenAPI spec included  

## Testing Checklist
- [ ] Completed reports can be downloaded successfully
- [ ] Non-completed reports return 400 Bad Request
- [ ] Non-existent reports return 404 Not Found
- [ ] File size and content integrity are preserved
- [ ] Large files (>100MB) download correctly
- [ ] Proper HTTP headers are set
- [ ] Error responses include meaningful messages

## Related Issues
Resolves: AuthorizationFailure when downloading reports from private blob storage